### PR TITLE
Node: remove "prepare" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "clean": "rimraf dist build",
     "test": "electron-mocha --recursive dist/test",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "format": "p() { prettier ${@:- --write} package.json '*.js' '**/*.{css,js,json,md,scss,ts,tsx}'; }; p",
-    "prepare": "yarn tsc"
+    "format": "p() { prettier ${@:- --write} package.json '*.js' '**/*.{css,js,json,md,scss,ts,tsx}'; }; p"
   },
   "dependencies": {
     "bindings": "^1.5.0"


### PR DESCRIPTION
The `prepare` script in `package.json` is causing installation issues. [This commit in libsignal-client][0] fixes it.

The "right thing" to do seems to be a full build to this repo. I'm opening this pull request in case it's easier to just merge this for now. Feel free to close if this isn't the right idea.

Tested this by running `node package.json`, which exited fine, verifying that this is valid JSON. (Didn't do any more thorough testing.)

[0]: https://github.com/signalapp/libsignal-client/commit/37b9cd363f645a9f8bd3e8170ccbba0054045164